### PR TITLE
Allow development build from unity part on custom build window

### DIFF
--- a/Scripts/Support/Editor/CustomBuild/CustomBuildUnityExport/CustomBuildUnityExport2018.cs
+++ b/Scripts/Support/Editor/CustomBuild/CustomBuildUnityExport/CustomBuildUnityExport2018.cs
@@ -17,6 +17,13 @@ public class CustomBuildUnityExport2018 : CustomBuildUnityExport
         EditorUserBuildSettings.SwitchActiveBuildTarget(buildTargetGroup,
                                                         buildTarget);
 
+
+        if(EditorUserBuildSettings.development)
+        {
+            buildOptions = buildOptions| BuildOptions.Development | BuildOptions.AllowDebugging;
+        }
+
+
         UnityEditor.Build.Reporting.BuildReport error = 
             BuildPipeline.BuildPlayer(scenesPath, containerPath, buildTarget, 
                                       buildOptions);
@@ -28,6 +35,8 @@ public class CustomBuildUnityExport2018 : CustomBuildUnityExport
             error.summary.result == 
                 UnityEditor.Build.Reporting.BuildResult.Cancelled
         );
+
+
 
         if (fail)
         {

--- a/Scripts/Support/Editor/CustomBuild/CustomBuildUnityExport/CustomBuildUnityExport_2017_OR_LOWER.cs
+++ b/Scripts/Support/Editor/CustomBuild/CustomBuildUnityExport/CustomBuildUnityExport_2017_OR_LOWER.cs
@@ -28,6 +28,11 @@ public class CustomBuildUnityExport2017OrLower : CustomBuildUnityExport
         //File.Move(rightDllLoc, tempDllLoc);
         //AssetDatabase.Refresh();
 
+        if (EditorUserBuildSettings.development)
+        {
+            buildOptions = buildOptions | BuildOptions.Development | BuildOptions.AllowDebugging;
+        }
+
         string s = BuildPipeline.BuildPlayer(scenesPath, containerPath, 
                                              buildTarget,
                                              buildOptions).ToString();


### PR DESCRIPTION
- Checks if it is a development build and concats into the build options the Development and AllowDebugging options.